### PR TITLE
Update analyze_sites.plot_annot_stats to filter to protein controllers and human sites

### DIFF
--- a/protmapper_paper/analyze_sites.py
+++ b/protmapper_paper/analyze_sites.py
@@ -74,7 +74,7 @@ def create_site_csv(site_dict, mapping_results, site_file, annot_file):
                            source, ms.gene_name, ms.up_id, ms.error_code,
                            ms.valid, ms.orig_res, ms.orig_pos, ms.mapped_id,
                            ms.mapped_res, ms.mapped_pos, ms.description, side,
-                           True, len(stmts)])
+                           True, len(stmts), 0, 0])
     print("Saving %d site entries to %s" % (len(all_sites)-1, site_file))
     with open(site_file, 'wt') as f:
         csvwriter = csv.writer(f)


### PR DESCRIPTION
Also adds an additional field to Table 1 for total unique annotations after mapping, which accounts for the redundancy that can occur when mapped sites become identical to valid sites after mapping.